### PR TITLE
어세스토큰유효하지않은경우 401반환하도록 수정

### DIFF
--- a/src/main/java/com/campustable/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/campustable/be/domain/auth/service/AuthService.java
@@ -113,7 +113,7 @@ public class AuthService {
     RefreshToken existingRefreshToken = refreshTokenRepository.findById(jti)
         .orElseThrow(()->{
           log.error("redis에 refreshToken이존재하지 않습니다.");
-          return new CustomException(ErrorCode.JWT_INVALID);
+          return new CustomException(ErrorCode.REFRESH_TOKEN_EXPIRED);
         });
     Long userId = existingRefreshToken.getUserId();
     refreshTokenRepository.delete(existingRefreshToken);
@@ -121,7 +121,7 @@ public class AuthService {
     User user = userRepository.findById(userId)
         .orElseThrow(()->{
           log.error("refreshToken에 해당하는 유저가 존재하지않습니다.");
-          return new CustomException(ErrorCode.USER_NOT_FOUND);
+          return new CustomException(ErrorCode.REFRESH_TOKEN_INVALID);
         });
 
     String refreshTokenId = UUID.randomUUID().toString();

--- a/src/main/java/com/campustable/be/global/exception/ErrorCode.java
+++ b/src/main/java/com/campustable/be/global/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
 
   ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,"Access Token이 만료되었습니다. 재발급이 필요합니다."),
 
-  JWT_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 정보입니다. 다시 로그인해 주세요."),
+  JWT_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 정보입니다. 다시 로그인해 주세요."),
 
   REFRESH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다. 다시 로그인해 주세요."),
 


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 토큰 관련 오류 응답의 HTTP 상태 코드를 개선했습니다. 인증 정보 유효성 검증 실패 시 이제 올바른 상태 코드(401 Unauthorized)를 반환합니다.
  * 토큰 재발급 시 오류 구분을 명확히 했습니다. 토큰 만료와 사용자 정보 부재 시나리오에 대해 더 정확한 오류 응답을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->